### PR TITLE
Replace gammaCorrection hack with sRGB color interpolation

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,16 +10,6 @@ const PLUGIN_NAME = require('./package.json').name;
 const VALID_EXTS = ['.png'];
 
 /**
- * Gamma correction for semi-transparent pixels.
- * @see  https://github.com/Quasimondo/QuasimondoJS/blob/ce7ffb317f7435940046d5ff46a7503f92efd328/zorrosvg/js/zorrosvgmaskmaker.js#L223-L225
- * @param  {Number}  value
- * @return {Number}
- */
-function gammaCorrection(value) {
-  return Math.floor(Math.pow(value / 255, 0.45) * 255);
-}
-
-/**
  * Wrap image and luminance mask in a ZorroSVG file.
  * @see https://github.com/Quasimondo/QuasimondoJS/blob/ce7ffb317f7435940046d5ff46a7503f92efd328/zorrosvg/js/zorrosvgmaskmaker.js#L400-L449
  * @param  {Buffer}  buffer
@@ -33,7 +23,7 @@ function getSvg(buffer, params) {
     path: params.path.replace('.png', '.svg'),
     contents: Buffer.from(`<svg width="${params.width}" height="${params.height / 2}" viewBox="0 0 ${params.width} ${params.height / 2}" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>
-    <filter id="zorrosvg" primitiveUnits="objectBoundingBox">
+    <filter id="zorrosvg" primitiveUnits="objectBoundingBox" color-interpolation-filters="sRGB">
       <feOffset in="SourceGraphic" result="bottom-half" dy="-0.5"></feOffset>
       <feColorMatrix type="matrix" in="bottom-half" result="luma-mask" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0"></feColorMatrix>
       <feComposite in="SourceGraphic" in2="luma-mask" operator="in"></feComposite>
@@ -112,7 +102,7 @@ module.exports = (options) => {
         // Create a luminance mask based on the original image's alpha channel
         // Add gamma correction for semi-transparent pixels
         for (let i = compositeBuffer.length / 2; i < compositeBuffer.length; i = i + 4) {
-          let alpha = gammaCorrection(compositeBuffer[i + 3]);
+          let alpha = compositeBuffer[i + 3];
           compositeBuffer[i + 0] = alpha;
           compositeBuffer[i + 1] = alpha;
           compositeBuffer[i + 2] = alpha;


### PR DESCRIPTION
TIL that SVG filters default to “linearRGB”, which produces washed-out colors (for example, see [`test/water-output-incorrect.jpg`](https://github.com/tannerhodges/gulp-zorrosvg/blob/96c94a16324bae9b24797eabb63248f76d8b176d/test/water-output-incorrect.jpg)).

We’ve been using a [`gammaCorrection` hack](https://github.com/tannerhodges/gulp-zorrosvg/blob/96c94a16324bae9b24797eabb63248f76d8b176d/index.js#L12-L20) to convert linearRGB values to sRGB, which raised each value to the power of `1/2.2` (or `0.45` for short).

While this worked, it’s neither the simplest nor the most accurate solution. Now that I understand the problem, fixing it simply a matter of adding `color-interpolation-filters="sRGB"` to the filter.

## References

- [Twitter: TIL sRGB encodes gamma values but linearRGB doesn't](https://twitter.com/atannerhodges/status/1021101810919116802)
- [CodePen: “SVG color-interpolation-filters” by hellokatili](https://codepen.io/hellokatili/pen/pbExyV)
- [Tavmjong Bah: Color Interpolation in SVG](http://tavmjong.free.fr/blog/?p=765)
- [Stack Overflow: “Convert RGB to sRGB?” answer by Sanchit](https://stackoverflow.com/a/40547615/1786459)